### PR TITLE
make stylist work from subfolder

### DIFF
--- a/src/Stylist/Html/ThemeHtmlBuilder.php
+++ b/src/Stylist/Html/ThemeHtmlBuilder.php
@@ -91,7 +91,7 @@ class ThemeHtmlBuilder
      */
     public function url($file = '')
     {
-        return '/'.$this->assetUrl($file);
+        return url($this->assetUrl($file));
     }
 
     /**

--- a/tests/Html/ThemeHtmlBuilderTest.php
+++ b/tests/Html/ThemeHtmlBuilderTest.php
@@ -47,7 +47,7 @@ class ThemeHtmlBuilderTest extends TestCase
 
     public function testAssetUrlResponse()
     {
-        $this->assertEquals('/themes/parent-theme/', $this->builder->url());
-        $this->assertEquals('/themes/parent-theme/favicon.ico', $this->builder->url('favicon.ico'));
+        $this->assertEquals(url('themes/parent-theme/'), $this->builder->url());
+        $this->assertEquals(url('themes/parent-theme/favicon.ico'), $this->builder->url('favicon.ico'));
     }
 }


### PR DESCRIPTION
I think its not a good idea, to hardcode "/" as the public base_path (since then, working in a subfolder eg. dev.server/folder wont work.)
Changed to url() and it works like expected.