### PR TITLE
Register Parent theme after child theme

### DIFF
--- a/src/Stylist/Theme/Stylist.php
+++ b/src/Stylist/Theme/Stylist.php
@@ -134,11 +134,11 @@ class Stylist
      */
     protected function activateFinderPaths(Theme $theme)
     {
+        $this->view->addLocation($theme->getPath().'/views/');
+
         if ($theme->hasParent()) {
             $this->activateFinderPaths($this->get($theme->getParent()));
         }
-
-        $this->view->addLocation($theme->getPath().'/views/');
     }
 
     /**


### PR DESCRIPTION
This is so that the finder looks in the child theme before the parent theme, so inheritence functions properly.

I've been having issues with this, I've got a theme that has another theme as it's parent but because the parent is registered first the Laravel Finder looks in the parent theme before the child theme, which is surely the wrong way around.

I think this references Issue #12 