### PR TITLE
Change use of bindShared to singleton

### DIFF
--- a/src/Stylist/StylistServiceProvider.php
+++ b/src/Stylist/StylistServiceProvider.php
@@ -67,7 +67,8 @@ class StylistServiceProvider extends AggregateServiceProvider
      */
     protected function registerStylist()
     {
-        $this->app->bindShared('stylist', function($app) {
+        $this->app->singleton('stylist', function($app)
+        {
             return new Stylist(new Loader, $app);
         });
     }


### PR DESCRIPTION
bindShared have been removed in Laravel 5.2
issue #27 