### PR TITLE
Revert "Use prependLocation() instead of addLocation() to allow overriding theme after boot"

### DIFF
--- a/src/Stylist/Theme/Stylist.php
+++ b/src/Stylist/Theme/Stylist.php
@@ -134,11 +134,11 @@ class Stylist
      */
     protected function activateFinderPaths(Theme $theme)
     {
+        $this->view->addLocation($theme->getPath().'/views/');
+
         if ($theme->hasParent()) {
             $this->activateFinderPaths($this->get($theme->getParent()));
         }
-
-        $this->view->getFinder()->prependLocation($theme->getPath().'/views/');
     }
 
     /**


### PR DESCRIPTION
Reverts floatingpointsoftware/stylist#36