### PR TITLE
For compattibility with Url::asset() and Html::style/script()

### DIFF
--- a/src/Stylist/Html/ThemeHtmlBuilder.php
+++ b/src/Stylist/Html/ThemeHtmlBuilder.php
@@ -91,7 +91,7 @@ class ThemeHtmlBuilder
      */
     public function url($file = '')
     {
-        return url($this->assetUrl($file));
+        return asset($this->assetUrl($file));
     }
 
     /**


### PR DESCRIPTION
Why? 
Because when we install Laravel in to a sub folder (ex: /laravelapp) we need to refer all our assets urls to this subfolder.

And laravel stuff yet do this in example `Html::script('')` return `http://domain.com/laravelapp` because it look what is set in `app.asset_url`

Also all other `Theme::style/script/image/linkAsset()`  will return url with subfolder included `http://domain.com/laravelapp`

But not for `Theme::url()` that use `url() helper` of Laravel that generate url from root and not in accord with config `app.asset_url`
so we need to replace it to `asset()` that work with assets and not app root url