### PR TITLE
Tagging for Laravel 5.8 and Laravel 6.x tests fix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Then, make sure the Stylist service provider is made available to your applicati
 
     'FloatingPoint\Stylist\StylistServiceProvider',
 
+## Version Compatibility
+
+ Laravel  | Stylist
+:---------|:----------
+ 5.5      | <1.0
+ 5.8      | 1.1
+ 6.x      | 2.x
+ 7.x      | 3.x
+
+
 You're now ready to go!
 
 ## Setting up a theme

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,13 @@
     }
   ],
   "require": {
-    "php": "^7.0",
-    "laravelcollective/html": "~5.5",
-    "illuminate/support": "~5.5"
+    "php": "^7.1",
+    "illuminate/support": "^6.0|^7.0",
+    "laravel/framework": "^6.0|^7.0",
+    "laravelcollective/html": "^6.0|^7.0"
   },
   "require-dev": {
-    "mockery/mockery": "^0.9.5",
-    "orchestra/testbench": "~3.0",
-    "phpunit/phpunit": "~6.0"
+    "orchestra/testbench": "^4.0|^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
+
 >
     <testsuites>
         <testsuite name="Unit">

--- a/tests/Html/ThemeHtmlBuilderTest.php
+++ b/tests/Html/ThemeHtmlBuilderTest.php
@@ -21,28 +21,28 @@ class ThemeHtmlBuilderTest extends TestCase
     {
         $script = $this->builder->script('script.js');
 
-        $this->assertContains('/themes/parent-theme/script.js', (string) $script);
+        $this->assertStringContainsString('/themes/parent-theme/script.js', (string) $script);
     }
 
     public function testStyleUrlCreation()
     {
         $style = $this->builder->script('css/app.css');
 
-        $this->assertContains('/themes/parent-theme/css/app.css', (string) $style);
+        $this->assertStringContainsString('/themes/parent-theme/css/app.css', (string) $style);
     }
 
     public function testImageUrlCreation()
     {
         $image = $this->builder->image('images/my-image.png');
 
-        $this->assertContains('/themes/parent-theme/images/my-image.png', (string) $image);
+        $this->assertStringContainsString('/themes/parent-theme/images/my-image.png', (string) $image);
     }
 
     public function testHtmlLinkAssetCreation()
     {
         $flashLink = $this->builder->linkAsset('swf/video.swf');
 
-        $this->assertContains('/themes/parent-theme/swf/video.swf', (string) $flashLink);
+        $this->assertStringContainsString('/themes/parent-theme/swf/video.swf', (string) $flashLink);
     }
 
     public function testAssetUrlResponse()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,13 +5,13 @@ use Mockery as m;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
-    public function tearDown()
+    public function tearDown(): void
     {
         parent::tearDown();
         m::close();
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Theme/JsonTest.php
+++ b/tests/Theme/JsonTest.php
@@ -2,6 +2,7 @@
 namespace Tests\Theme;
 
 use FloatingPoint\Stylist\Theme\Json;
+use FloatingPoint\Stylist\Theme\Exceptions\ThemeJsonNotFoundException;
 
 class JsonTest extends \Tests\TestCase
 {
@@ -28,10 +29,12 @@ class JsonTest extends \Tests\TestCase
     }
 
     /**
-     * @expectedException FloatingPoint\Stylist\Theme\Exceptions\ThemeJsonNotFoundException
+     * @expectException FloatingPoint\Stylist\Theme\Exceptions\ThemeJsonNotFoundException
      */
     public function testThemeFileMissing()
     {
+        $this->expectException(ThemeJsonNotFoundException::class);
+
         $json = new Json('path/that/doesnt/exist');
 
         $json->getJson();

--- a/tests/Theme/StylistTest.php
+++ b/tests/Theme/StylistTest.php
@@ -4,6 +4,7 @@ namespace Tests\Theme;
 use FloatingPoint\Stylist\Theme\Loader;
 use FloatingPoint\Stylist\Theme\Stylist;
 use FloatingPoint\Stylist\Theme\Theme;
+use FloatingPoint\Stylist\Theme\Exceptions\ThemeNotFoundException;
 
 class StylistTest extends \Tests\TestCase
 {
@@ -66,10 +67,11 @@ class StylistTest extends \Tests\TestCase
     }
 
     /**
-     * @expectedException FloatingPoint\Stylist\Theme\Exceptions\ThemeNotFoundException
+     * @expectException FloatingPoint\Stylist\Theme\Exceptions\ThemeNotFoundException
      */
     public function testInvalidTheme()
     {
+        $this->expectException(ThemeNotFoundException::class);
         $stylist = new Stylist(new Loader, $this->app);
         $stylist->get('invalidtheme');
     }


### PR DESCRIPTION
Tagging for Laravel 5.8 and Laravel 6.x tests fix.